### PR TITLE
Uses screen dimensions for Android devices to account for soft menu bar

### DIFF
--- a/lib/camera.js
+++ b/lib/camera.js
@@ -3,6 +3,7 @@ import React, {
   Animated,
   View,
   StyleSheet,
+  Platform,
   Dimensions
 } from 'react-native';
 
@@ -10,7 +11,7 @@ import * as util from './util';
 import Vector2D from './vector2d';
 import SceneSide from './scene_side';
 
-const window = Dimensions.get('window');
+const window = Dimensions.get(Platform.OS === 'android' ? 'screen' : 'window');
 
 const SCENE_REF = 'SCENE_REF';
 


### PR DESCRIPTION
Now that React Native 0.20 is exposing screen dimensions for Android, we can use it to avoid having wrong camera size. Still need to use window for iOS.
